### PR TITLE
fix() price ATC

### DIFF
--- a/vnstock/stock.py
+++ b/vnstock/stock.py
@@ -177,8 +177,11 @@ def price_depth (stock_list='VPB,TCB', headers=vps_headers):
     # for all columns has "Giá" in the name, convert to value then multiply by 1000, set as integer
     for col in df.columns:
         if 'Giá' in col:
-            df[col] = df[col].astype(float)*1000
-            df[col] = df[col].astype(int)
+            try:
+                df[col] = df[col].astype(float)*1000
+                df[col] = df[col].astype(int)
+            except:
+                pass
     return df
 
 def price_board (symbol_ls):


### PR DESCRIPTION
#### What this PR does / why we need it
- add a try-except block to retrieve the price At The Close in `price_depth`
### What is the purpose of your *pull request*?
- [x] Bug fix
- [ ] Improvement
- [ ] New feature
#### Special notes for your reviewer
-  JSON sample for this case
```
[
  {
    "id": 2100,
    "sym": "TAR",
    "mc": "02",
    "c": 19.4,
    "f": 16,
    "r": 17.7,
    "lastPrice": 17.9,
    "lastVolume": 9300,
    "lot": 378440,
    "ot": "0.20",
    "changePc": "1.13",
    "avePrice": "18.10",
    "highPrice": "18.40",
    "lowPrice": "17.70",
    "fBVol": "0",
    "fBValue": "0",
    "fSVolume": "0",
    "fSValue": "0",
    "fRoom": "0",
    "g1": "ATC|1240|e",
    "g2": "18.10|500|i",
    "g3": "18.00|4550|i",
    "g4": "ATC|8250|e",
    "g5": "17.80|900|i",
    "g6": "17.90|150|i",
    "g7": "65040|161650|e",
    "mp": "0%",
    "CWUnderlying": "",
    "CWIssuerName": "",
    "CWType": "",
    "CWMaturityDate": "",
    "CWLastTradingDate": "",
    "CWExcersisePrice": "0",
    "CWExerciseRatio": "",
    "CWListedShare": "0.00",
    "sType": "S",
    "sBenefit": "0"
  }
]
```
- Got the error:
```
    df[col] = df[col].astype(float)*1000
              ^^^^^^^^^^^^^^^^^^^^^
...
    return arr.astype(dtype, copy=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: could not convert string to float: 'ATC'
```