### PR TITLE
test: add unit test for funds.py

### DIFF
--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -1,0 +1,27 @@
+import pandas as pd
+from vnstock.funds import funds_listing
+
+def assert_valid_dataframe(result):
+    assert isinstance(result, pd.DataFrame)
+    assert len(result) > 0
+
+class TestFundsListing:
+    # Retrieve list of available funds with default parameters
+    def test_default_parameters(self):
+        result = funds_listing()
+        assert_valid_dataframe(result)
+    
+    # Retrieve list of available funds with all parameters specified
+    def test_all_parameters_specified(self):
+        result = funds_listing(lang='en', fund_type="STOCK", mode="full", decor=False)
+        assert_valid_dataframe(result)
+    
+    # Retrieve list of available funds with unsupported language
+    def test_unsupported_language(self):
+        result = funds_listing(lang='fr')
+        assert_valid_dataframe(result)
+    
+    # Retrieve list of available funds with unsupported fund type
+    def test_unsupported_fund_type(self):
+        result = funds_listing(fund_type="INVALID")
+        assert_valid_dataframe(result)


### PR DESCRIPTION
Starting with a few initial test cases to examine the functionality of `funds_listing()`. Additional ones will be added later if you have interest in this automated approach.

Dev need to install `pytest` package.

Benefits of this approach (vs run and verify manually all of functions in a notebook):
- simpler to test: just `pytest ./tests/`
- easier to verify: we can see clearly the total number of pass/fail cases