### PR TITLE
chores: refactor module funds

### DIFF
--- a/tests/test_funds.py
+++ b/tests/test_funds.py
@@ -1,31 +1,113 @@
-import unittest
+import pytest
 import pandas as pd
-from vnstock.funds import funds_listing
+from vnstock.funds import *
 
-def assert_valid_dataframe(result):
+
+def assert_dataframe_not_empty(result):
     assert isinstance(result, pd.DataFrame)
     assert len(result) > 0
 
-class TestFundsListing (unittest.TestCase):
-    # Retrieve list of available funds with default parameters
-    def test_default_parameters(self):
-        result = funds_listing()
-        assert_valid_dataframe(result)
-    
-    # Retrieve list of available funds with all parameters specified
-    def test_all_parameters_specified(self):
-        result = funds_listing(lang='en', fund_type="STOCK", mode="full", decor=False)
-        assert_valid_dataframe(result)
-    
-    # Retrieve list of available funds with unsupported language
-    def test_unsupported_language(self):
-        result = funds_listing(lang='fr')
-        assert_valid_dataframe(result)
-    
-    # Retrieve list of available funds with unsupported fund type
-    def test_unsupported_fund_type(self):
-        result = funds_listing(fund_type="INVALID")
-        assert_valid_dataframe(result)
 
-if __name__ == '__main__':
-    unittest.main()
+# Retrieve non-empty dataframe with default parameters
+def test_default_parameters():
+    result = funds_listing()
+    assert_dataframe_not_empty(result)
+
+    result = fund_details()
+    assert_dataframe_not_empty(result)
+
+    result = fund_filter()
+    assert_dataframe_not_empty(result)
+
+    result = fund_top_holding()
+    assert_dataframe_not_empty(result)
+
+    result = fund_industry_holding()
+    assert_dataframe_not_empty(result)
+
+    result = fund_nav_report()
+    assert_dataframe_not_empty(result)
+
+    result = fund_asset_holding()
+    assert_dataframe_not_empty(result)
+
+
+# Retrieve non-empty dataframe with specified parameters
+def test_parameters_specified():
+    result = funds_listing(fund_type="BALANCED")
+    assert_dataframe_not_empty(result)
+
+    result = funds_listing(fund_type="BOND")
+    assert_dataframe_not_empty(result)
+
+    result = funds_listing(fund_type="STOCK")
+    assert_dataframe_not_empty(result)
+
+    result = fund_details(symbol="SSISCA", type="top_holding_list")
+    assert_dataframe_not_empty(result)
+
+    result = fund_details(symbol="SSISCA", type="industry_holding_list")
+    assert_dataframe_not_empty(result)
+
+    result = fund_details(symbol="SSISCA", type="nav_report")
+    assert_dataframe_not_empty(result)
+
+    result = fund_details(symbol="SSISCA", type="asset_holding_list")
+    assert_dataframe_not_empty(result)
+
+    result = fund_filter(symbol="SSISCA")
+    assert_dataframe_not_empty(result)
+
+    result = fund_top_holding(fundId=23)
+    assert_dataframe_not_empty(result)
+
+    result = fund_industry_holding(fundId=23)
+    assert_dataframe_not_empty(result)
+
+    result = fund_nav_report(fundId=23)
+    assert_dataframe_not_empty(result)
+
+    result = fund_asset_holding(fundId=23)
+    assert_dataframe_not_empty(result)
+
+
+# Assert error with unsupported param input
+def test_funds_listing_invalid_input():
+    # expected ouput is a non-empty dataframe
+    result = funds_listing(fund_type="INVALID")
+    assert_dataframe_not_empty(result)
+
+
+def test_fund_details_invalid_symbol():
+    with pytest.raises(ValueError):
+        fund_details(symbol="invalid_symbol")
+
+
+def test_fund_details_invalid_type():
+    with pytest.raises(ValueError):
+        fund_details(type="invalid_type")
+
+
+def test_fund_filter_invalid_symbol():
+    with pytest.raises(ValueError):
+        fund_filter(symbol="invalid_symbol")
+
+
+def test_fund_top_holding_invalid_fund_id():
+    with pytest.raises(requests.exceptions.HTTPError):
+        fund_top_holding(fundId=999)
+
+
+def test_fund_industry_holding_invalid_fund_id():
+    with pytest.raises(requests.exceptions.HTTPError):
+        fund_industry_holding(fundId=999)
+
+
+def test_fund_asset_holding_invalid_fund_id():
+    with pytest.raises(requests.exceptions.HTTPError):
+        fund_asset_holding(fundId=999)
+
+
+def test_fund_nav_report_invalid_fund_id():
+    with pytest.raises(ValueError):
+        fund_nav_report(fundId=999)

--- a/vnstock/funds.py
+++ b/vnstock/funds.py
@@ -2,56 +2,53 @@ from .config import *
 
 # UTILS
 
+
 def convert_unix_to_datetime(
-        df_to_convert: pd.DataFrame, columns: list[str]
+    df_to_convert: pd.DataFrame, columns: list[str]
 ) -> pd.DataFrame:
     """Converts all the specified columns of a dataframe to date format and fill NaN for negative values."""
     df = df_to_convert.copy()
     for col in columns:
-        df[col] = pd.to_datetime(df[col], unit='ms', utc=True, errors='coerce').dt.strftime('%Y-%m-%d')
-        df[col] = df[col].where(df[col].ge('1970-01-01'))
+        df[col] = pd.to_datetime(
+            df[col], unit="ms", utc=True, errors="coerce"
+        ).dt.strftime("%Y-%m-%d")
+        df[col] = df[col].where(df[col].ge("1970-01-01"))
     return df
+
 
 # MUTUAL FUNDS
 
-def funds_listing(lang='vi', fund_type="", mode="simplify", decor=True, headers=fmarket_headers):
+
+def funds_listing(fund_type="", headers=fmarket_headers) -> pd.DataFrame:
     """
     Retrieve list of available funds from Fmarket. Live data is retrieved from the Fmarket API. Visit https://fmarket.vn to learn more.
-    
+
     Parameters
     ----------
-        lang: str
-            language of the column label. Options: 'vi' (default), 'en'
-        fund_type: list
+        fund_type : list
             available fund types: "" (default), "BALANCED", "BOND", "STOCK"
-        mode: str
-            return only important columns or all available info. Options: "simplify" (default), "full"
-        decor: bool
-            transform column label to Title Case. Options: True (default), False
-        headers: dict
+        headers : dict
             headers of the request
-    
+
     Returns
     -------
-        df: pd.DataFrame
+        df : pd.DataFrame
             DataFrame of all available mutual fund listed on Fmarket.
     """
-    # Check language input. Default to Vietnamese if the chosen language is not supported
-    supported_languages = {'en': 'English', 'vi': 'Tiếng Việt'}
-    if lang.lower() not in supported_languages:
-        print(f"Warning: Unsupported language '{lang}', defaulting to Vietnamese.")
-        lang = 'vi'
-    
+
     # Check fund_type input
+    fund_type = fund_type.upper()
     fundAssetTypes = {
         "": [],
         "BALANCED": ["BALANCED"],
         "BOND": ["BOND"],
-        "STOCK": ["STOCK"]
+        "STOCK": ["STOCK"],
     }.get(fund_type, [])
-        
-    if fund_type not in ["", "BALANCED", "BOND", "STOCK"]:
-        print(f"Warning: Unsupported fund type '{fund_type}', defaulting to all fund types.")
+
+    if fund_type not in {"", "BALANCED", "BOND", "STOCK"}:
+        print(
+            f"Warning: Unsupported fund type '{fund_type}', defaulting to all fund types."
+        )
 
     # API call
     payload = {
@@ -66,188 +63,208 @@ def funds_listing(lang='vi', fund_type="", mode="simplify", decor=True, headers=
         "bondRemainPeriods": [],
         "searchField": "",
         "isBuyByReward": False,
-        "thirdAppIds": []
+        "thirdAppIds": [],
     }
     url = "https://api.fmarket.vn/res/products/filter"
     response = requests.post(url, json=payload, headers=headers)
     status = response.status_code
     if status == 200:
         data = response.json()
-        print('Total number of funds currently listed on Fmarket: ', data['data']['total'])
-        df = json_normalize(data, record_path=['data', 'rows'])
+        print(
+            "Total number of funds currently listed on Fmarket: ", data["data"]["total"]
+        )
+        df = json_normalize(data, record_path=["data", "rows"])
 
-        # rearrange columns to display
-        column_subset_full = [
-            'id',
-            'shortName',
-            'name',
-            'dataFundAssetType.name',
-            'owner.name',
-            'managementFee',
-            'firstIssueAt',
-            'productNavChange.navToPrevious',
-            'productNavChange.navToLastYear',
-            'productNavChange.navToBeginning',
-            'productNavChange.navTo1Months',
-            'productNavChange.navTo3Months',
-            'productNavChange.navTo6Months',
-            'productNavChange.navTo12Months',
-            'productNavChange.navTo24Months',
-            'productNavChange.navTo36Months',
-            'productNavChange.annualizedReturn36Months',
-            'productNavChange.updateAt',
-            'nav',
-            'code',
-            'vsdFeeId',
+        # select columns to display
+        column_subset = [
+            "shortName",
+            "name",
+            "dataFundAssetType.name",
+            "owner.name",
+            "managementFee",
+            "firstIssueAt",
+            "nav",
+            "productNavChange.navToPrevious",
+            "productNavChange.navToLastYear",
+            "productNavChange.navToBeginning",
+            "productNavChange.navTo1Months",
+            "productNavChange.navTo3Months",
+            "productNavChange.navTo6Months",
+            "productNavChange.navTo12Months",
+            "productNavChange.navTo24Months",
+            "productNavChange.navTo36Months",
+            "productNavChange.annualizedReturn36Months",
+            "productNavChange.updateAt",
+            "id",
+            "code",
+            "vsdFeeId",
         ]
-        column_subset_simplified = [
-            'id',
-            'shortName',
-            'name',
-            'dataFundAssetType.name',
-            'owner.name',
-            'managementFee',
-            'productNavChange.navTo6Months',
-            'productNavChange.navTo36Months',
-            'nav',
-            'code',
-        ]
-        # choose column_subset based on user input param "mode"
-        column_subsets = {
-            "simplify": column_subset_simplified,
-            "full": column_subset_full
-        }
-        df = df[column_subsets.get(mode, column_subset_simplified)]
+
+        df = df[column_subset]
 
         # Convert Unix timestamp to date format
-        if mode == "full":
-            df = convert_unix_to_datetime(
-                df_to_convert=df,
-                columns=[
-                    'firstIssueAt', 
-                    'productNavChange.updateAt'
-                    ]
-                )
-
-        # set data type for columns, id to int
-        df = df.astype({'id': 'int'})
+        df = convert_unix_to_datetime(
+            df_to_convert=df, columns=["firstIssueAt", "productNavChange.updateAt"]
+        )
 
         # sort by '36-month NAV change'
-        df = df.sort_values(by='productNavChange.navTo36Months', ascending=False)
-        
-        # rename column label according to language choice
-        language_mappings = {
-            'vi': {
-                'id': 'fundId',
-                'shortName': 'Tên viết tắt',
-                'name': 'Tên CCQ',
-                'dataFundAssetType.name': 'Loại Quỹ',
-                'owner.name': 'Tổ chức phát hành',
-                'managementFee': 'Phí quản lý (%)',
-                'productNavChange.navTo6Months': 'Lợi nhuận 6 tháng gần nhất (%)',
-                'productNavChange.navTo36Months': 'Lợi nhuận 3 năm gần nhất (%)',
-                'nav': 'Giá gần nhất'
-            },
-            'en': {
-                'shortName': 'Fund short name',
-                'name': 'Fund name',
-                'owner.name': 'Fund owner',
-                'dataFundAssetType.name': 'Fund asset type',
-                'managementFee': 'Management fee (%)',                                           
-                'productNavChange.navTo6Months': '6-month NAV change (%)',
-                'productNavChange.navTo36Months': '3-year NAV change (%)',
-                'nav': 'NAV/Unit (VND)',
-                'id': 'fundId'
-            }
+        df = df.sort_values(by="productNavChange.navTo36Months", ascending=False)
+
+        # rename column label to snake_case
+        column_mapping = {
+            "shortName": "short_name",
+            "name": "name",
+            "dataFundAssetType.name": "fund_type",
+            "owner.name": "fund_owner_name",
+            "managementFee": "management_fee",
+            "firstIssueAt": "inception_date",
+            "nav": "nav",
+            "productNavChange.navToPrevious": "nav_change_previous",
+            "productNavChange.navToLastYear": "nav_change_last_year",
+            "productNavChange.navToBeginning": "nav_change_inception",
+            "productNavChange.navTo1Months": "nav_change_1m",
+            "productNavChange.navTo3Months": "nav_change_3m",
+            "productNavChange.navTo6Months": "nav_change_6m",
+            "productNavChange.navTo12Months": "nav_change_12m",
+            "productNavChange.navTo24Months": "nav_change_24m",
+            "productNavChange.navTo36Months": "nav_change_36m",
+            "productNavChange.annualizedReturn36Months": "nav_change_36m_annualized",
+            "productNavChange.updateAt": "nav_update_at",
+            "id": "fund_id_fmarket",
+            "code": "fund_code",
+            "vsdFeeId": "vsd_fee_id",
         }
-        if decor==True:
-            column_mapping = language_mappings[lang.lower()]
-            df.rename(columns=column_mapping, inplace=True)
-        
+        df.rename(columns=column_mapping, inplace=True)
+
         # reset index column
         df = df.reset_index(drop=True)
-        # output                                                                                                            
-        return df
-    else:                               
-        print(f"Error in API response {response.text}", "\n")
 
-def fund_details (symbol='SSISCA', type='top_holding_list', headers=fmarket_headers):
+        return df
+    else:
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )
+
+
+def fund_details(
+    symbol="SSISCA", type="top_holding_list", headers=fmarket_headers
+) -> pd.DataFrame:
     """
     Retrieve fund details for a specific fund. Live data is retrieved from the Fmarket API.
-    Parameters:
-        symbol (str): ticker of a fund
-        type (str): type of data to retrieve. Default is 'top_holding_list', other options are 'industry_holding_list'
-        headers (dict): headers of the request. Default is fmaker_headers
-    Returns:
-        df (pd.DataFrame): DataFrame of the current top holdings of the selected fund.
-    """
-    # get fundID from symbol using fund_filter
-    fundID = str(fund_filter (payload={"searchField": symbol, "pageSize": 1, "types": ["NEW_FUND", "TRADING_FUND"]})['id'][0])
-    print(f'Getting data for {symbol}')
-    if type == 'top_holding_list':
-        df = fund_top_holding(fundId=fundID, lang='vi', headers=headers)
-    elif type == 'industry_holding_list':
-        df = fund_industry_holding(fundId=fundID, lang='vi', headers=headers)
-    elif type == 'nav_report':
-        df = fund_nav_report(fundId=fundID, lang='vi', headers=headers)
-    elif type == 'asset_holding_list':
-        df = fund_asset_holding(fundId=fundID, lang='vi', headers=headers)
-    else:
-        print('Please specify type of data to retrieve.')
-    try:
-        df['symbol'] = symbol
-    except:
-        pass
-    return df
 
-# payload = {
-#   "types": [
-#     "NEW_FUND",
-#     "TRADING_FUND"
-#   ],
-#   "issuerIds": [],
-#   "sortOrder": "DESC",
-#   "sortField": "annualizedReturn36Months",
-#   "page": 1,
-#   "pageSize": 100,
-#   "isIpo": False,
-#   "fundAssetTypes": [],
-#   "bondRemainPeriods": [],
-#   "searchField": "VESAF",
-#   "isBuyByReward": False,
-#   "thirdAppIds": []
-# }
-
-def fund_filter (payload={"types": ["NEW_FUND", "TRADING_FUND"], "pageSize": 100, "searchField": "VESAF"}, columns=['id', 'shortName', 'name', 'description'], headers=fmarket_headers):
-  url = "https://api.fmarket.vn/res/products/filter"
-  payload = json.dumps(payload)
-  response = requests.request("POST", url, headers=headers, data=payload)
-  if response.status_code == 200:
-    data = response.json()
-    df = json_normalize(data, record_path=['data', 'rows'])
-    # subset df to get only the columns in column_subset
-    df = df[columns]
-    return df
-
-def fund_top_holding(fundId=23, lang='vi', headers=fmarket_headers):
-    """
-    Retrieve list of top 10 holdings in the specified fund. Live data is retrieved from the Fmarket API.
-    
     Parameters
     ----------
-        fundId (int): id of a fund in fmarket database. Retrieved from the 'fundId_fmarket' column by calling the function mutual_fund_listing()
-        lang (str): language of the column label. Supported: 'vi' (default), 'en'
-        headers (dict): headers of the request. Default is fmaker_headers
-    
+        symbol : str
+            ticker of a fund. A.k.a fund short name
+        type : str
+            type of data to retrieve. Options: 'top_holding_list' (default), 'industry_holding_list', 'nav_report', 'asset_holding_list'
+        headers : dict
+            headers of the request. Options: fmaker_headers (default)
+
     Returns
     -------
-    df (pd.DataFrame): DataFrame of the current top 10 holdings of the selected fund.
+        df : pd.DataFrame
+            DataFrame of the current top holdings of the selected fund.
     """
-    # Check language input. Default to Vietnamese if the chosen language is not supported
-    supported_languages = {'en': 'English', 'vi': 'Tiếng Việt'}
-    if lang.lower() not in supported_languages:
-        print(f"Warning: Unsupported language '{lang}', defaulting to Vietnamese.")
-        lang = 'vi'
+
+    # validate "symbol" param input
+    symbol = symbol.upper()
+    try:
+        # Lookup a valid "fundID" related to "symbol"
+        # invalid symbol exception will be handled in fund_filter()
+        fundID = int(fund_filter(symbol)["id"][0])
+        print(f"Retrieving data for {symbol}")
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        raise e
+
+    # validate "type" param input
+    type_mappings = {
+        "top_holding_list": fund_top_holding,
+        "industry_holding_list": fund_industry_holding,
+        "nav_report": fund_nav_report,
+        "asset_holding_list": fund_asset_holding,
+    }
+
+    if type in type_mappings:
+        # Match with appropriate function
+        df = type_mappings[type](fundId=fundID, headers=headers)
+        df["short_name"] = symbol
+        return df
+    else:
+        print(
+            f"Error: {type} is not a valid input.\n"
+            f"4 current options are:\n"
+            f"top_holding_list\n"
+            f"industry_holding_list\n"
+            f"nav_report\n"
+            f"asset_holding_list"
+        )
+        raise ValueError
+
+
+def fund_filter(symbol="", headers=fmarket_headers) -> pd.DataFrame:
+    """Filter FundID based on Fund short name
+
+    Parameters
+    ----------
+        symbol : str
+            Fund short name. Empty string by default to list all available fund short name and their FundID
+        headers : dict
+            headers of API request. Options: fmarket_headers (default)
+
+    Returns
+    -------
+        df : pd.DataFrame
+            DataFrame of filtered funds
+    """
+
+    symbol = symbol.upper()
+
+    payload = {
+        "searchField": symbol,
+        "types": ["NEW_FUND", "TRADING_FUND"],
+        "pageSize": 100,
+    }
+    url = "https://api.fmarket.vn/res/products/filter"
+    payload = json.dumps(payload)
+    response = requests.post(url, data=payload, headers=headers)
+
+    if response.status_code == 200:
+        data = response.json()
+        df = json_normalize(data, record_path=["data", "rows"])
+        if not df.empty:
+            # retrieve only column_subset
+            column_subset = ["id", "shortName"]
+            df = df[column_subset]
+            return df
+        else:
+            raise ValueError(
+                f"No fund found with this symbol {symbol}.\n"
+                f"See funds_listing() for the list of valid Fund short names."
+            )
+    else:
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )
+
+
+def fund_top_holding(fundId=23, headers=fmarket_headers) -> pd.DataFrame:
+    """
+    Retrieve list of top 10 holdings in the specified fund. Live data is retrieved from the Fmarket API.
+
+    Parameters
+    ----------
+        fundId : int
+            id of a fund in fmarket database
+        headers : dict
+            headers of the request. Options: fmaker_headers (default)
+
+    Returns
+    -------
+        df : pd.DataFrame
+            DataFrame of the current top 10 holdings of the selected fund.
+    """
 
     # API call
     # Logic: there are funds which allocate to either equities or fixed income securities, or both
@@ -259,132 +276,125 @@ def fund_top_holding(fundId=23, lang='vi', headers=fmarket_headers):
         df = pd.DataFrame()
 
         # Flatten top holding equities
-        df_stock = json_normalize(
-            data, 
-            record_path=['data', 'productTopHoldingList']
-            )
+        df_stock = json_normalize(data, record_path=["data", "productTopHoldingList"])
         if not df_stock.empty:
             # Convert unix timestamp into date format
-            df_stock['updateAt'] = pd.to_datetime(df_stock['updateAt'], unit='ms', utc=True).dt.strftime('%Y-%m-%d')
+            df_stock = convert_unix_to_datetime(
+                df_to_convert=df_stock, columns=["updateAt"]
+            )
             # Merge to output
             df = pd.concat([df, df_stock])
-        else:
-            pass
 
         # Flatten top holding fixed income securities
         df_bond = json_normalize(
-            data, 
-            record_path=['data', 'productTopHoldingBondList']
-            )
+            data, record_path=["data", "productTopHoldingBondList"]
+        )
         if not df_bond.empty:
-            df_bond['updateAt'] = pd.to_datetime(df_bond['updateAt'], unit='ms', utc=True).dt.strftime('%Y-%m-%d')
+            df_bond = convert_unix_to_datetime(
+                df_to_convert=df_bond, columns=["updateAt"]
+            )
             df = pd.concat([df, df_bond])
-        else:
-            pass
-        
-        # if df is not empty, then go ahead
+
+        # if df is not empty, then rearrange and return df as output
         if not df.empty:
-            df['fundId'] = str(fundId)
+            df["fundId"] = int(fundId)
             # rearrange columns to display
             column_subset = [
-                'stockCode',
-                'industry',
-                'netAssetPercent',
-                'type',
-                'updateAt',
-                'fundId'
+                "stockCode",
+                "industry",
+                "netAssetPercent",
+                "type",
+                "updateAt",
+                "fundId",
             ]
             df = df[column_subset]
 
-            # rename column label according to language choice
-            language_mappings = {
-                'vi': {
-                    'stockCode': 'Tên',
-                    'industry': 'Ngành',
-                    'netAssetPercent': '% Giá trị tài sản',
-                    'type': 'Loại tài sản',
-                    'updateAt': 'Cập nhật lần cuối',
-                },
-                'en': {
-                    'stockCode': 'Stock code',
-                    'industry': 'Industry',
-                    'netAssetPercent': '% NAV',
-                }
+            # rename column label to snake_case
+            column_mapping = {
+                "stockCode": "stock_code",
+                "industry": "industry",
+                "netAssetPercent": "net_asset_percent",
+                "type": "type_asset",
+                "updateAt": "update_at",
             }
-            column_mapping = language_mappings[lang.lower()]
             df.rename(columns=column_mapping, inplace=True)
 
-            # output
             return df
         else:
             print(f"Warning: No data available for fundId {fundId}.")
-            return None
+            return pd.DataFrame()
     else:
-        print(f"Error in API response {response.text}", "\n")
+        # invalid fundId error is 400 from api
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )
 
 
-def fund_industry_holding (fundId=23, lang='vi', headers=fmarket_headers):
-    """
-    Retrieve list of industries and fund distribution for specific fundID. Live data is retrieved from the Fmarket API.
-    """
-    # Check language input. Default to Vietnamese if the chosen language is not supported
-    supported_languages = {'en': 'English', 'vi': 'Tiếng Việt'}
-    if lang.lower() not in supported_languages:
-        print(f"Warning: Unsupported language '{lang}', defaulting to Vietnamese.")
-        lang = 'vi'
+def fund_industry_holding(fundId=23, headers=fmarket_headers) -> pd.DataFrame:
+    """Retrieve list of industries and fund distribution for specific fundID. Live data is retrieved from the Fmarket API.
 
-    # API call
-    # Logic: there are funds which allocate to either equities or fixed income securities, or both
-    url = f"https://api.fmarket.vn/res/products/{fundId}"
-    response = requests.get(url, headers=headers, cookies=None)
-    if response.status_code == 200:
-        data = response.json()
-        df = json_normalize(data, record_path=['data', 'productIndustriesHoldingList'])
-        # drop id column
-        try:
-            df.drop(columns=['id'], inplace=True)
-        except:
-            pass
-        columns_mapping = {'vi': {
-                            'industry': 'Ngành',
-                            'assetPercent': '% Giá trị tài sản',
-                            },
-                            'en': {
-                            'industry': 'Industry',
-                            'assetPercent': '% NAV',
-                            }
-                            }
-        df.rename(columns=columns_mapping[lang.lower()], inplace=True)
-        return df
-    else:
-        print(f"Error in API response {response.text}", "\n")
-
-
-def fund_nav_report(fundId='23', lang='vi', headers=fmarket_headers):
-    """Retrieve all available daily NAV data point of the specified fund. Live data is retrieved from the Fmarket API.
     Parameters
     ----------
-        symbol: int
-            id of a fund in fmarket database. Retrieved from the 'fundId' column by calling the function mutual_fund_listing()
-        lang: str
-            language of the column label. Supported: 'vi' (default), 'en'
-        headers: dict
-            headers of the request. Default is fmaker_headers
-    
+        fundId : int
+            id of a fund in fmarket database
+        headers : dict
+            headers of the request. Options: fmaker_headers (default)
+
     Returns
     -------
-        df: pd.DataFrame
-            DataFrame of all avalaible daily NAV data points of the selected fund.
+        df : pd.DataFrame
+            DataFrame of the current top industries in the selected fund.
     """
-    # Check language input. Default to Vietnamese if the chosen language is not supported
-    supported_languages = {'en': 'English', 'vi': 'Tiếng Việt'}
-    if lang.lower() not in supported_languages:
-        print(f"Warning: Unsupported language '{lang}', defaulting to Vietnamese.")
-        lang = 'vi'
 
     # API call
-    # Get the current date and format it as 'yyyyMMdd'
-    current_date = datetime.now().strftime('%Y%m%d')
+    url = f"https://api.fmarket.vn/res/products/{fundId}"
+    response = requests.get(url, headers=headers, cookies=None)
+
+    if response.status_code == 200:
+        data = response.json()
+        df = json_normalize(data, record_path=["data", "productIndustriesHoldingList"])
+
+        # rearrange columns to display
+        column_subset = [
+            "industry",
+            "assetPercent",
+        ]
+        df = df[column_subset]
+
+        # rename column label to snake_case
+        columns_mapping = {
+            "industry": "industry",
+            "assetPercent": "net_asset_percent",
+        }
+        df.rename(columns=columns_mapping, inplace=True)
+
+        return df
+    else:
+        # invalid fundId error is 400 from api
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )
+
+
+def fund_nav_report(fundId=23, headers=fmarket_headers) -> pd.DataFrame:
+    """Retrieve all available daily NAV data point of the specified fund. Live data is retrieved from the Fmarket API.
+
+    Parameters
+    ----------
+        fundId : int
+            id of a fund in fmarket database.
+        headers : dict
+            headers of the request. Default is fmaker_headers
+
+    Returns
+    -------
+        df : pd.DataFrame
+            DataFrame of all avalaible daily NAV data points of the selected fund.
+    """
+
+    # API call
+    # Set the date range to the current date
+    current_date = datetime.now().strftime("%Y%m%d")
     url = "https://api.fmarket.vn/res/product/get-nav-history"
     payload = {
         "isAllData": 1,
@@ -396,75 +406,69 @@ def fund_nav_report(fundId='23', lang='vi', headers=fmarket_headers):
     status = response.status_code
     if status == 200:
         data = response.json()
-        df = json_normalize(
-            data, 
-            record_path=['data']
-            )
+        df = json_normalize(data, record_path=["data"])
 
-        # rearrange columns to display
-        column_subset = [
-            'navDate',
-            'nav',
-            'productId'
-        ]
-        df = df[column_subset]
+        if not df.empty:
+            # rearrange columns to display
+            column_subset = ["navDate", "nav"]
+            df = df[column_subset]
 
-        # rename column label according to language choice
-        language_mappings = {
-            'vi': {
-                'navDate': 'Ngày',
-                'nav': 'Giá trị tài sản ròng/CCQ (VND)',
-                'productId': 'fundId'
-            },
-            'en': {
-                'navDate': 'Date',
-                'nav': 'NAV/Unit (VND)',
-                'productId': 'fundId'
+            # rename column label to snake_case
+            column_mapping = {
+                "navDate": "date",
+                "nav": "nav_per_unit",
             }
-        }
-        column_mapping = language_mappings[lang.lower()]
-        df.rename(columns=column_mapping, inplace=True)
+            df.rename(columns=column_mapping, inplace=True)
 
-        # output
-        return df
+            return df
+        else:
+            raise ValueError(f"No data with this fund_id {fundId}")
     else:
-        print(f"Error in API response {response.text}", "\n")
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )
 
 
-def fund_asset_holding (fundId=23, lang='vi', headers=fmarket_headers):
+def fund_asset_holding(fundId=23, headers=fmarket_headers) -> pd.DataFrame:
+    """Retrieve list of assets holding allocation for specific fundID. Live data is retrieved from the Fmarket API.
+
+    Parameters
+    ----------
+        fundId : int
+            id of a fund in fmarket database.
+        headers : dict
+            headers of the request. Default is fmaker_headers
+
+    Returns
+    -------
+        df : pd.DataFrame
+            DataFrame of assets holding allocation of the selected fund.
     """
-    Retrieve list of assets holding allocation for specific fundID. Live data is retrieved from the Fmarket API.
-    """
-    # Check language input. Default to Vietnamese if the chosen language is not supported
-    supported_languages = {'en': 'English', 'vi': 'Tiếng Việt'}
-    if lang.lower() not in supported_languages:
-        print(f"Warning: Unsupported language '{lang}', defaulting to Vietnamese.")
-        lang = 'vi'
 
     # API call
-    # Logic: there are funds which allocate to either equities or fixed income securities, or both
     url = f"https://api.fmarket.vn/res/products/{fundId}"
     response = requests.get(url, headers=headers, cookies=None)
     if response.status_code == 200:
         data = response.json()
-        df = json_normalize(data, record_path=['data', 'productAssetHoldingList'])
-        try:
-            # drop id column
-            df.drop(columns=['id', 'assetType.id', 'assetType.code', 'assetType.colorCode', 'createAt'], inplace=True)
-            # convert updateAt to YYYY-mm-dd format
-            df['updateAt'] = pd.to_datetime(df['updateAt'], unit='ms', utc=True).dt.strftime('%Y-%m-%d')
-        except:
-            pass
-        columns_mapping = {'vi': {
-                            'assetPercent': 'Tỉ trọng',
-                            'assetType.name': 'Loại tài sản',
-                            },
-                            'en': {
-                            'assetPercent': 'assetPercent',
-                            'assetType.name': 'assetType',
-                            }
-                            }
-        df.rename(columns=columns_mapping[lang.lower()], inplace=True)
+        df = json_normalize(data, record_path=["data", "productAssetHoldingList"])
+
+        # rearrange columns to display
+        column_subset = [
+            "assetPercent",
+            "assetType.name",
+        ]
+        df = df[column_subset]
+
+        # rename column label to snake_case
+        column_mapping = {
+            "assetPercent": "asset_percent",
+            "assetType.name": "asset_type",
+        }
+        df.rename(columns=column_mapping, inplace=True)
+
         return df
     else:
-        print(f"Error in API response {response.text}", "\n")
+        # invalid fundId error is 400 from api
+        raise requests.exceptions.HTTPError(
+            f"Error in API response: {response.status_code} - {response.text}"
+        )


### PR DESCRIPTION
changelog:
- refactor code for better readability
- add type hints for the output of each function
- add error/exception handling for invalid input in `fund_details` and its dependent functions
- standardize column label of output dataframe to snake_case
- remove ambiguous input param `lang`, `mode`, `decor` from all of the functions' logic
- format code with [ruff](https://docs.astral.sh/ruff/) package
- update `test_funds.py` according to changes in `funds.py`

unit tests `test_funds.py` are all passed, before making PR.

```bash
vnstock on  chores/funds/refactor-funds-module [!?] is 󰏗 v0.2.8.7.dev.23  via  v3.9.18 via  dev-vnstock took 49s
❯ pytest .\tests\test_funds.py
====================================================================== test session starts =======================================================================
platform win32 -- Python 3.9.18, pytest-7.4.3, pluggy-1.3.0
rootdir: ~\my_workspace\andrey-jef\vnstock
plugins: cov-4.1.0
collected 10 items

tests\test_funds.py ..........                                                                                                                              [100%] 

====================================================================== 10 passed in 47.35s ======================================================================= 
```