### PR TITLE
fix: funds module bug with py38

### DIFF
--- a/vnstock/funds.py
+++ b/vnstock/funds.py
@@ -1,10 +1,11 @@
 from .config import *
+from typing import List
 
 # UTILS
 
 
 def convert_unix_to_datetime(
-    df_to_convert: pd.DataFrame, columns: list[str]
+    df_to_convert: pd.DataFrame, columns: List[str]
 ) -> pd.DataFrame:
     """Converts all the specified columns of a dataframe to date format and fill NaN for negative values."""
     df = df_to_convert.copy()
@@ -25,7 +26,7 @@ def funds_listing(fund_type="", headers=fmarket_headers) -> pd.DataFrame:
 
     Parameters
     ----------
-        fund_type : list
+        fund_type : str
             available fund types: "" (default), "BALANCED", "BOND", "STOCK"
         headers : dict
             headers of the request


### PR DESCRIPTION
hot fix for #107 in situation where some users want to stay at `python=3.8`

In this case these users must also downgrade pandas to `pandas = "^2.0.3"`, since the latest version of pandas `2.1.4` requires `python=3.9`

Unit tests in `Python 3.8.18`

```shell
vnstock on  fix/funds/support-python-38 [!?] is 󰏗 v0.2.8.7.dev.24  via  v3.8.18 via  dev-vnstock-py38 took 2s
❯ pytest -v .\tests\test_funds.py
====================================================================== test session starts =======================================================================
platform win32 -- Python 3.8.18, pytest-7.4.4, pluggy-1.3.0 -- ~\envs\dev-vnstock-py38\python.exe
cachedir: .pytest_cache
rootdir: ~\my_workspace\andrey-jef\vnstock
plugins: cov-4.1.0
collected 10 items

tests/test_funds.py::test_parameters_specified PASSED                                                                                                       [ 20%] 
tests/test_funds.py::test_funds_listing_invalid_input PASSED                                                                                                [ 30%] 
tests/test_funds.py::test_fund_details_invalid_symbol PASSED                                                                                                [ 40%] 
tests/test_funds.py::test_fund_details_invalid_type PASSED                                                                                                  [ 50%] 
tests/test_funds.py::test_fund_filter_invalid_symbol PASSED                                                                                                 [ 60%] 
tests/test_funds.py::test_fund_top_holding_invalid_fund_id PASSED                                                                                           [ 70%] 
tests/test_funds.py::test_fund_industry_holding_invalid_fund_id PASSED                                                                                      [ 80%] 
tests/test_funds.py::test_fund_asset_holding_invalid_fund_id PASSED                                                                                         [ 90%] 
tests/test_funds.py::test_fund_nav_report_invalid_fund_id PASSED                                                                                            [100%] 

====================================================================== 10 passed in 48.47s ======================================================================= 