### PR TITLE
fix: Fixed a bug where StockComponents would receive None as symbol when source was None

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ dev/MSN_quarter_reports_df.xlsx
 dev/vci_financial_test_notebook_Nov_1.ipynb
 vnstock/.DS_Store
 .DS_Store
+
+*.pyc

--- a/tests/common/test_data_explorer.py
+++ b/tests/common/test_data_explorer.py
@@ -21,6 +21,21 @@ class TestVnstock(unittest.TestCase):
         stock = vnstock.stock(symbol="ACB")
         self.assertIsInstance(stock, StockComponents)
         self.assertEqual(stock.symbol, "ACB")
+    
+    def test_stock_with_none_source(self):
+        """Test that the stock method correctly sets symbol when source is None"""
+        vnstock = Vnstock()
+        # Test with symbol provided and source=None
+        stock_comp = vnstock.stock(symbol="VNM", source=None)
+        self.assertEqual(stock_comp.symbol, "VNM")
+        
+        # Test with default symbol and source=None
+        stock_comp = vnstock.stock(symbol=None, source=None)
+        self.assertEqual(stock_comp.symbol, "VN30F1M")
+        
+        # Test with symbol provided and source provided
+        stock_comp = vnstock.stock(symbol="VNM", source="VCI")
+        self.assertEqual(stock_comp.symbol, "VNM")
 
     def test_vnstock_fx(self):
         vnstock = Vnstock(source="MSN")

--- a/vnstock/common/vnstock.py
+++ b/vnstock/common/vnstock.py
@@ -38,11 +38,12 @@ class Vnstock:
         if symbol is None:
             self.symbol = 'VN30F1M'
             logger.info("Mã chứng khoán không được chỉ định, chương trình mặc định sử dụng VN30F1M")
+        else:
+            self.symbol = symbol
 
         if source is None:
             source = self.source
-        else:
-            self.symbol = symbol
+        
         return StockComponents(self.symbol, source, show_log=self.show_log)
     
     def fx(self, symbol: Optional[str]='EURUSD', source: Optional[str] = "MSN"):


### PR DESCRIPTION
## Changes
Fixed a bug where StockComponents would receive None as symbol when source was None. The fix ensures that self.symbol is properly set regardless of the source value:
- When symbol is provided, it's always set to self.symbol
- When symbol is None, it uses the default 'VN30F1M'

Added tests to verify the fix works correctly.
Also updated .gitignore to ignore .pyc files.

## Reproduce
Feed only symbol, not source, then symbol gets reset to None
```python
Vnstock().stock(symbol='VCB').symbol
```
<img width="569" alt="image" src="https://github.com/user-attachments/assets/cc91a7b9-311b-4c39-b3d6-910b13a72098" />

Expect outout to be `VCB`

There is a broken test as well. This PR fixes it.

<img width="670" alt="SCR-20250307-scuj" src="https://github.com/user-attachments/assets/b1c885f0-92cf-4b0e-8f69-2111a4371193" />
