### PR TITLE
fix: add column to process for multi-language dictionary extraction

### DIFF
--- a/vnstock/explorer/tcbs/screener.py
+++ b/vnstock/explorer/tcbs/screener.py
@@ -151,7 +151,10 @@ class Screener:
                 "price_vs_sma5",
                 "company_name",    
                 "industry",   
-                "exchange"    
+                "exchange",
+                "uptrend",
+                "price_break_out52_week",
+                "heating_up"
             ]
             
             # Process the specified columns:


### PR DESCRIPTION
fix: 3 columns not extracted, only get Vietnamese language
![image](https://github.com/user-attachments/assets/1e78e74f-030a-48d9-8835-daf31ef0c853)
