### PR TITLE
fix: add price_wash_out52_week column for multi-language dictionary extraction

### DIFF
--- a/vnstock/explorer/tcbs/screener.py
+++ b/vnstock/explorer/tcbs/screener.py
@@ -154,6 +154,7 @@ class Screener:
                 "exchange",
                 "uptrend",
                 "price_break_out52_week",
+                "price_wash_out52_week",
                 "heating_up"
             ]
             


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d672c225-5c5b-4466-8bff-f8807db45218)
