### PR TITLE
refactor: change default value of symbol parameter to None in Trading…

### DIFF
--- a/vnstock/api/trading.py
+++ b/vnstock/api/trading.py
@@ -25,7 +25,7 @@ class Trading(BaseAdapter):
     def __init__(
         self,
         source: str = "vci",
-        symbol: str = "",
+        symbol: str = None,
         random_agent: bool = False,
         show_log: bool = False
     ):


### PR DESCRIPTION
# Change default symbol parameter in base Trading class

## Description
This PR changes the default value of the `symbol` parameter in the base `Trading` class from an empty string `""` to `None`. This change aligns with the implementation in explorer classes (like VCI's Trading class) where the default value is `None`.

## Impact
The change affects all explorer classes that inherit from the base `Trading` class, particularly:

1. VCI Trading explorer (`vnstock/explorer/vci/trading.py`):
   - Currently uses `symbol:Optional[str]='VCI'` as default
   - The base class change ensures consistent behavior across the codebase

2. Other explorer classes that inherit from base Trading:
   - Will now properly handle `None` as the default value
   - Maintains consistency with the explorer implementations

## Technical Details
- Changed parameter in `vnstock/api/trading.py`:
  ```python
  def __init__(
      self,
      source: str = "vci",
      symbol: str = None,  # Changed from symbol: str = ""
      random_agent: bool = False,
      show_log: bool = False
  )
  ```

## Testing
- Verify that all explorer classes work correctly with the new default value
- Ensure backward compatibility with existing code that might pass empty string as symbol
- Test cases with both `None` and empty string `""` as symbol values
