### PR TITLE
fix: `Invalid derivative or bond symbol. Symbol must be in format` for `VN30F1Q`, `VN30F2Q`

### DIFF
--- a/vnstock/core/utils/parser.py
+++ b/vnstock/core/utils/parser.py
@@ -146,7 +146,7 @@ def get_asset_type(symbol: str) -> str:
     # For symbols that could be derivative or bond (length 7 or 9)
     elif len(symbol) in [7, 9]:
         # VN30 derivative patterns:
-        fm_pattern = re.compile(r'^VN30F\d{1,2}M$')
+        fm_pattern = re.compile(r'^VN30F\d{1,2}[MQ]$')
         ym_pattern = re.compile(r'^VN30F\d{4}$')
         
         # Bond patterns:


### PR DESCRIPTION
Thêm pattern bị thiếu cho `VN30F1Q` và `VN30F2Q`.

Ngoài ra, phần pattern các symbol phái sinh của VN100, gồm `VN100F1M`, `VN100F2M`, `VN100F1Q`, `VN100F2Q` cũng bị thiếu. Tuy nhiên, mình chưa sửa vì: 
- code không báo lỗi
- những symbol này có 8 ký tự, nếu sửa sẽ xung đột với `Covered warrant`