### PR TITLE
fix: add error handling for empty or malformed responses in VCI GraphQL requests

### DIFF
--- a/vnstock/explorer/vci/company.py
+++ b/vnstock/explorer/vci/company.py
@@ -98,6 +98,12 @@ class Company:
             request_mode=self.proxy_config.request_mode
         )
         
+        if not response_data or 'data' not in response_data:
+            raise ValueError(
+                f"VCI GraphQL returned empty/malformed response for '{self.symbol}'. "
+                f"Upstream may be unavailable. Try source='KBS' as fallback. "
+                f"Raw: {response_data!r}"
+            )
         return response_data['data']
 
     def _process_data(self, data: Dict, data_key: str, 

--- a/vnstock/explorer/vci/financial.py
+++ b/vnstock/explorer/vci/financial.py
@@ -252,6 +252,13 @@ class Finance:
             request_mode=self.proxy_config.request_mode
         )
         
+        if not response_data or 'data' not in response_data:
+            raise ValueError(
+                f"VCI GraphQL returned empty/malformed response for '{self.symbol}'. "
+                f"Upstream may be unavailable. Try source='KBS' as fallback. "
+                f"Raw: {response_data!r}"
+            )
+
         # Extract relevant data
         try:
             selected_data = response_data['data']['CompanyFinancialRatio']['ratio']


### PR DESCRIPTION
VCI GraphQL đang trả {} cho mọi ticker → vnstock crash với KeyError: 'data' không rõ nguyên nhân
  
-> Fix thêm guard ở 2 code path (company._fetch_data, financial._get_report), raise ValueError với message rõ symbol + gợi ý fallback source='KBS'